### PR TITLE
Convert to Central Package Management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="System.Text.Json" Version="9.0.0-preview.6.24327.7" />
+  </ItemGroup>
+</Project>

--- a/src/AspNetCorePlayground/AspNetCorePlayground.csproj
+++ b/src/AspNetCorePlayground/AspNetCorePlayground.csproj
@@ -7,14 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="9.0.0-preview.6.24327.7" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-preview.6.24328.4" />
-    <PackageReference Include="Serilog" Version="4.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
-    <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Serilog.Enrichers.Environment" />
+    <PackageReference Include="Serilog.Enrichers.Process" />
+    <PackageReference Include="Serilog.Settings.Configuration" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/AspNetCorePlayground/Directory.Packages.props
+++ b/src/AspNetCorePlayground/Directory.Packages.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-preview.6.24328.4" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUi" Version="6.6.1" />
+  </ItemGroup>
+</Project>

--- a/src/AspNetCorePlayground/Directory.Packages.props
+++ b/src/AspNetCorePlayground/Directory.Packages.props
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)../'))" />
-
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-preview.6.24328.4" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUi" Version="6.6.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUi" Version="6.7.0" />
   </ItemGroup>
 </Project>

--- a/src/AspNetCorePlayground/Program.cs
+++ b/src/AspNetCorePlayground/Program.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.HttpLogging;
 using Serilog;
 using Serilog.Events;
 
-// This enables ASP.NET Core HTTP integration tests to set-up Serilog so that tests gets logging
+// This enables ASP.NET Core HTTP integration tests to setup Serilog so that tests gets logging
 if (Log.Logger == Serilog.Core.Logger.None)
 {
     Log.Logger = new LoggerConfiguration()
@@ -71,7 +71,9 @@ try
             // If console is deemed in Azure environments there it is probably a good idea to add
             // https://nuget.org/packages/serilog.sinks.async
             // as console historically has been known to slow things down a lot
-            _ = configuration.WriteTo.Console(outputTemplate: SerilogTemplates.IncludesProperties, restrictedToMinimumLevel: LogEventLevel.Error); // Console is terribly ineffective, so limiting to the really bad stuff
+
+            // Console is terribly ineffective, so limiting to the really bad stuff
+            _ = configuration.WriteTo.Console(outputTemplate: SerilogTemplates.IncludesProperties, restrictedToMinimumLevel: LogEventLevel.Error);
         }
         else
         {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <ItemGroup>
+    <PackageVersion Include="Serilog" Version="4.0.0" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.2" />
+  </ItemGroup>
+</Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)../'))" />
-
   <ItemGroup>
-    <PackageVersion Include="Serilog" Version="4.0.0" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageVersion Include="Serilog" Version="4.0.1" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.2" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.2" />

--- a/test/AspNetCorePlayground.WebApi.HttpIntegration/AspNetCorePlayground.WebApi.HttpIntegration.csproj
+++ b/test/AspNetCorePlayground.WebApi.HttpIntegration/AspNetCorePlayground.WebApi.HttpIntegration.csproj
@@ -2,30 +2,23 @@
 
   <PropertyGroup>
     <RootNamespace>ResumeService.Test.WebApi.HttpIntegration</RootNamespace>
-    <AssemblyName />
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.analyzers" Version="1.15.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-preview.6.24328.4" />
-    <PackageReference Include="Serilog.Sinks.XUnit.Injectable" Version="2.1.40" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="System.Text.Json" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers" />
+
+    <PackageReference Include="MartinCostello.Logging.XUnit" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Serilog.Sinks.XUnit.Injectable" />
     <!-- Transitive dependencies with CVEs -->
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0-preview.6.24327.7" />
+    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AspNetCorePlayground.WebApi.HttpIntegration/Directory.Packages.props
+++ b/test/AspNetCorePlayground.WebApi.HttpIntegration/Directory.Packages.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)../'))" />
+  <ItemGroup>
+    <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-preview.6.24328.4" />
+    <PackageVersion Include="Serilog.Sinks.XUnit.Injectable" Version="2.1.40" />
+    <!-- Transitive dependencies with CVEs -->
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+</Project>

--- a/test/AspNetCorePlayground.WebApi.HttpIntegration/Directory.Packages.props
+++ b/test/AspNetCorePlayground.WebApi.HttpIntegration/Directory.Packages.props
@@ -4,7 +4,7 @@
   <ItemGroup>
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-preview.6.24328.4" />
-    <PackageVersion Include="Serilog.Sinks.XUnit.Injectable" Version="2.1.40" />
+    <PackageVersion Include="Serilog.Sinks.XUnit.Injectable" Version="2.1.42" />
     <!-- Transitive dependencies with CVEs -->
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)../))" />
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.15.0" />
+    <GlobalPackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <GlobalPackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Want to separate src "production" and test dependencies to avoid test bleeding into "production" code as I have seen happen.

As this is a one-mand project that is unlikely to happen, but want to use tools just as I would on a real life project