### PR TITLE
Updating XUnit to latest (pre) v3 versions compatible with v2 'Core XUnit'

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -6,8 +6,8 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="xunit" Version="2.9.0" />
-    <PackageVersion Include="xunit.analyzers" Version="1.15.0" />
-    <GlobalPackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.analyzers" Version="1.16.0" />
+    <GlobalPackageReference Include="xunit.runner.visualstudio" Version="3.0.0-pre.30" />
     <GlobalPackageReference Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
New Analyzers and runner can be used with v2