### PR TITLE
Enabling XUnit v3 using Microsoft Testing Platform Part II: Removing Microsoft.NET.Test.Sdk

### DIFF
--- a/src/AspNetCorePlayground/Directory.Packages.props
+++ b/src/AspNetCorePlayground/Directory.Packages.props
@@ -3,6 +3,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)../'))" />
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUi" Version="7.2.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUi" Version="7.3.1" />
   </ItemGroup>
 </Project>

--- a/test/AspNetCorePlayground.WebApi.HttpIntegration/AspNetCorePlayground.WebApi.HttpIntegration.csproj
+++ b/test/AspNetCorePlayground.WebApi.HttpIntegration/AspNetCorePlayground.WebApi.HttpIntegration.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="NSubstitute" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -2,7 +2,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)../))" />
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.v3" Version="1.1.0" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -2,7 +2,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)../))" />
   <ItemGroup>
-    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
+    <PackageVersion Include="FluentAssertions" Version="7.2.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.v3" Version="1.1.0" />
     <PackageVersion Include="xunit.analyzers" Version="1.20.0">


### PR DESCRIPTION
Can run tests using dotnet CLI and VS 17.13.0 Preview 3.0, but not using Rider 2024.3

This Rider issue needs to be resolved

https://youtrack.jetbrains.com/issue/RSRP-498837/Support-Microsoft.Testing.Platform-tests-discovery-without-Microsoft.NET.Test.Sdk